### PR TITLE
handle images scaled via CSS

### DIFF
--- a/zpl-image.js
+++ b/zpl-image.js
@@ -24,7 +24,8 @@ function imageToZ64(img, opts) {
 
 	cvs.width  = +img.width || img.offsetWidth;
 	cvs.height = +img.height || img.offsetHeight;
-	ctx.drawImage(img, 0, 0);
+	ctx.imageSmoothingQuality = 'high'; // in case canvas needs to scale image
+	ctx.drawImage(img, 0, 0, cvs.width, cvs.height);
 
 	let pixels = ctx.getImageData(0, 0, cvs.width, cvs.height);
 	return rgbaToZ64(pixels.data, pixels.width, opts);


### PR DESCRIPTION
Currently if an image was scaled via CSS, the ctx.drawImage() call draws the image in its original dimension, but getImageData() gets the data in the CSS dimension. This disconnect results in a clipped image.

I've added code to allow canvas to auto-scale the image (if it has to).